### PR TITLE
[FIX] Double quotes not being encoded within Jitsi URL

### DIFF
--- a/src/videoConfProvider.ts
+++ b/src/videoConfProvider.ts
@@ -72,13 +72,13 @@ export class JitsiProvider implements IVideoConfProvider {
 		const configs: string[] = [];
 
 		if (this.chromeExtensionId) {
-			configs.push(`config.desktopSharingChromeExtId="${this.chromeExtensionId}"`);
+			configs.push(`config.desktopSharingChromeExtId=${encodeURIComponent(`"${this.chromeExtensionId}"`)}`);
 		}
 
 		const title = call.providerData?.customCallTitle || call.title;
 
 		if (title) {
-			configs.push(`config.callDisplayName="${encodeURIComponent(title)}"`);
+			configs.push(`config.callDisplayName=${encodeURIComponent(`"${title}"`)}`);
 		}
 
 		if (options.mic !== undefined) {
@@ -93,7 +93,7 @@ export class JitsiProvider implements IVideoConfProvider {
 		// If it's not using a generated token, include extra settings openly
 		if (!token) {
 			if (user) {
-				configs.push(`userInfo.displayName="${encodeURIComponent(user.name)}"`);
+				configs.push(`userInfo.displayName=${encodeURIComponent(`"${user.name}"`)}`);
 			}
 		}
 


### PR DESCRIPTION
Right now the link is not encoding double quotes which is causing issues when we send this link to WhatsApp within the text message. If you may notice in the below image, the first Jitsi call message appears as a broken link due to the quotes. 
The later message is sent with this fix in place. As you can see, when the quotes are encode, whatsapp is properly able to parse the call link on its UI and the whole link becomes clickable.

![WhatsApp Image 2023-02-15 at 18 29 12](https://user-images.githubusercontent.com/34130764/219034853-54d30395-1c36-4425-ac11-562dea301f8a.jpeg)
